### PR TITLE
Dodge/Def buffs for stationary or not/ Also modified dodge cap logic

### DIFF
--- a/EnemyAttack.cs
+++ b/EnemyAttack.cs
@@ -117,7 +117,20 @@ public class EnemyAttack : MonoBehaviour
                         Critico = true;
                         DamageTX = Mathf.RoundToInt(DamageTX * 2);
                     }
-                    if (Random.Range(0, 100) <= PlayerToAttack.GetComponent<PlayerStats>().Dodge_chance)
+                    float Adj_dodge_chance = 5; //JWR - Moving dodge bonus
+                    float Player_dodge_chance = PlayerToAttack.GetComponent<PlayerStats>().Dodge_chance;
+                    float Dodge_hard_cap = PlayerToAttack.GetComponent<PlayerStats>().Dodge_hard_cap;
+	                if (Player_dodge_chance > (Dodge_hard_cap - 5)) { Adj_dodge_chance = Player_dodge_chance - (Dodge_hard_cap - 5); }
+	                if (Player_dodge_chance >= Dodge_hard_cap) { Adj_dodge_chance = 0; }
+                    if (!PlayerMPSync.stationary) // JWR
+                    {
+	    	            Adj_dodge_chance += PlayerStats.Dodge_chance; // JWR - Add bonus if moving
+	                }
+                    else
+	                {
+	    	            Adj_dodge_chance = PlayerStats.Dodge_chance; // JWR - No bonus if stationary
+	                }
+                    if (Random.Range(0, 100) <= Adj_dodge_chance)
                     {
                         dodged = true;
                         DamageTX = 0;

--- a/PlayerPVPDamage.cs
+++ b/PlayerPVPDamage.cs
@@ -263,21 +263,25 @@ public class PlayerPVPDamage : NetworkBehaviour
         float playerTotalDef = 0;
         float fromPlayerDamage = 0;
         float nerfDamage = 0.35f;
+        float pvpPdefBonus = PlayerStats.Defense_from_pdef * 1.0f; //JWR - Pdef bonus using base defense before armor/buff
+        float pvpMdefBonus = PlayerStats.Defense_from_mdef * 1.0f; //JWR - Mdef bonus using base defense before armor/buff
 
         switch (fromPlayerStats.DamageType_now)
         {
             case PlayerStats.DamageType.magical:
                 playerTotalDef = PlayerStats.Defense_int + (PlayerStats.Defense_str * 0.2f);
+                playerTotalDef += pvpMdefBonus; //JWR - Add def bonus
                 fromPlayerDamage = fromPlayerStats.Damage_int;
                 break;
             case PlayerStats.DamageType.physical:
                 playerTotalDef = PlayerStats.Defense_str + (PlayerStats.Defense_int * 0.2f);
+                playerTotalDef += pvpPdefBonus; //JWR Add def bonus
                 fromPlayerDamage = fromPlayerStats.Damage_str;
                 break;
             default:
                 break;
         }
-
+        
         DamageRX = Mathf.RoundToInt((fromPlayerDamage - playerTotalDef) * nerfDamage);
 
         //if damage is below 0 make sure to return 0, a negative number here would heal the player instead (100HP-(-100 damage)=200)
@@ -558,15 +562,19 @@ public class PlayerPVPDamage : NetworkBehaviour
         float playerTotalDef = 0;
         float fromPlayerDamage = 0;
         float nerfDamage = 0.35f;
+        float pvpPdefBonus = PlayerStats.Defense_from_pdef * 1.0f; //JWR - Pdef bonus using base defense before armor/buff
+        float pvpMdefBonus = PlayerStats.Defense_from_mdef * 1.0f; //JWR - Mdef bonus using base defense before armor/buff
 
         switch (fromPlayerStats.DamageType_now)
         {
             case PlayerStats.DamageType.magical:
                 playerTotalDef = PlayerStats.Defense_int + (PlayerStats.Defense_str * 0.2f);
+                playerTotalDef += pvpMdefBonus; //JWR - Add def bonus
                 fromPlayerDamage = fromPlayerStats.Damage_int * power_multiplier;
                 break;
             case PlayerStats.DamageType.physical:
                 playerTotalDef = PlayerStats.Defense_str + (PlayerStats.Defense_int * 0.2f);
+                playerTotalDef += pvpPdefBonus; //JWR - Add def bonus
                 fromPlayerDamage = fromPlayerStats.Damage_str * power_multiplier;
                 break;
             default:

--- a/PlayerPVPDamage.cs
+++ b/PlayerPVPDamage.cs
@@ -18,7 +18,6 @@ public class PlayerPVPDamage : NetworkBehaviour
     #region PVP Data
     float pvp_damage_factor = 1f;
     float pvp_defense_bonus_modifier = 0.5f;
-    float pvp_dodge_bonus_modifier = 0.3f;
     [HideInInspector]
     public string PVPmodeOn;
     [HideInInspector]
@@ -187,10 +186,9 @@ public class PlayerPVPDamage : NetworkBehaviour
             }
 
             //dodge chance lottery
-            float Adj_dodge_chance = PlayerStats.Dodge_from_agi * pvp_dodge_bonus_modifier; //JWR - Moving dodge bonus based on agi (no gear)
-	    if (PlayerStats.Dodge_chance >= (PlayerStats.Dodge_hard_cap - 5)) { Adj_dodge_chance = (PlayerStats.Dodge_chance + Adj_dodge_chance) - 45; }
+            float Adj_dodge_chance = 5; //JWR - Moving dodge bonus
+	    if (PlayerStats.Dodge_chance > (PlayerStats.Dodge_hard_cap - 5)) { Adj_dodge_chance = PlayerStats.Dodge_chance - (PlayerStats.Dodge_hard_cap - 5); }
 	    if (PlayerStats.Dodge_chance >= PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = 0; }
-            if (Adj_dodge_chance > 5) { Adj_dodge_chance = 5; } //JWR - Cap bonus at 5%
             if (!PlayerMPSync.stationary) // JWR
             {
 	    	Adj_dodge_chance += PlayerStats.Dodge_chance; // JWR - Add bonus if moving
@@ -449,10 +447,9 @@ public class PlayerPVPDamage : NetworkBehaviour
                         }
 
                         //dodge chance lottery
-            		float Adj_dodge_chance = PlayerStats.Dodge_from_agi * pvp_dodge_bonus_modifier; //JWR - Moving dodge bonus based on agi (no gear)
-	    		if (PlayerStats.Dodge_chance >= (PlayerStats.Dodge_hard_cap - 5)) { Adj_dodge_chance = (PlayerStats.Dodge_chance + Adj_dodge_chance) - 45; }
+	            	float Adj_dodge_chance = 5; //JWR - Moving dodge bonus
+			if (PlayerStats.Dodge_chance > (PlayerStats.Dodge_hard_cap - 5)) { Adj_dodge_chance = PlayerStats.Dodge_chance - (PlayerStats.Dodge_hard_cap - 5); }
 	    		if (PlayerStats.Dodge_chance >= PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = 0; }
-            		if (Adj_dodge_chance > 5) { Adj_dodge_chance = 5; } //JWR - Cap bonus at 5%
             		if (!PlayerMPSync.stationary) // JWR
             		{
 				Adj_dodge_chance += PlayerStats.Dodge_chance; // JWR - Add bonus if moving

--- a/PlayerPVPDamage.cs
+++ b/PlayerPVPDamage.cs
@@ -594,13 +594,13 @@ public class PlayerPVPDamage : NetworkBehaviour
         {
             case PlayerStats.DamageType.magical:
                 playerTotalDef = PlayerStats.Defense_int + (PlayerStats.Defense_str * 0.2f);
-                playerTotalDef += pvpMdefBonus; //JWR - Add def bonus (general bonus for PvP balance)
+                //playerTotalDef += pvpMdefBonus; //JWR - Add def bonus (general bonus for PvP balance)
                 if (PlayerMPSync.stationary) { playerTotalDef += pvpMdefBonus; } //JWR - If stationary, double the defense bonus
                 fromPlayerDamage = fromPlayerStats.Damage_int * power_multiplier;
                 break;
             case PlayerStats.DamageType.physical:
                 playerTotalDef = PlayerStats.Defense_str + (PlayerStats.Defense_int * 0.2f);
-                playerTotalDef += pvpPdefBonus; //JWR - Add def bonus (general bonus for PvP balance)
+                //playerTotalDef += pvpPdefBonus; //JWR - Add def bonus (general bonus for PvP balance)
                 if (PlayerMPSync.stationary) { playerTotalDef += pvpPdefBonus; } //JWR - If stationary, double the defense bonus
                 fromPlayerDamage = fromPlayerStats.Damage_str * power_multiplier;
                 break;

--- a/PlayerPVPDamage.cs
+++ b/PlayerPVPDamage.cs
@@ -197,7 +197,7 @@ public class PlayerPVPDamage : NetworkBehaviour
 			{
 				Adj_dodge_chance = PlayerStats.Dodge_chance; // JWR - No bonus if stationary
 			}
-			if (Adj_dodge_chance > PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = PlayerStats.Dodge_hard_cap; } // JWR - still want hard cap
+//			if (Adj_dodge_chance > PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = PlayerStats.Dodge_hard_cap; } // JWR - still want hard cap
 
             if (Random.Range(1, 100) <= Adj_dodge_chance) //JWR - Use adjusted dodge chance
             {

--- a/PlayerPVPDamage.cs
+++ b/PlayerPVPDamage.cs
@@ -188,17 +188,17 @@ public class PlayerPVPDamage : NetworkBehaviour
 
             //dodge chance lottery
             float Adj_dodge_chance = PlayerStats.Dodge_from_agi * pvp_dodge_bonus_modifier; //JWR - Moving dodge bonus based on agi (no gear)
+	    if (PlayerStats.Dodge_chance >= (PlayerStats.Dodge_hard_cap - 5)) { Adj_dodge_chance = (PlayerStats.Dodge_chance + Adj_dodge_chance) - 45; }
+	    if (PlayerStats.Dodge_chance >= PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = 0; }
             if (Adj_dodge_chance > 5) { Adj_dodge_chance = 5; } //JWR - Cap bonus at 5%
             if (!PlayerMPSync.stationary) // JWR
             {
-				Adj_dodge_chance += PlayerStats.Dodge_chance; // JWR - Add bonus if moving
-			}
+	    	Adj_dodge_chance += PlayerStats.Dodge_chance; // JWR - Add bonus if moving
+	    }
             else
-			{
-				Adj_dodge_chance = PlayerStats.Dodge_chance; // JWR - No bonus if stationary
-			}
-//			if (Adj_dodge_chance > PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = PlayerStats.Dodge_hard_cap; } // JWR - still want hard cap
-
+	    {
+	    	Adj_dodge_chance = PlayerStats.Dodge_chance; // JWR - No bonus if stationary
+	    }
             if (Random.Range(1, 100) <= Adj_dodge_chance) //JWR - Use adjusted dodge chance
             {
                 DamageRX = 0;
@@ -449,18 +449,19 @@ public class PlayerPVPDamage : NetworkBehaviour
                         }
 
                         //dodge chance lottery
-                        float Adj_dodge_chance = PlayerStats.Dodge_from_agi * pvp_dodge_bonus_modifier; //JWR - Moving dodge bonus based on agi (no gear)
-                        if (Adj_dodge_chance > 5) { Adj_dodge_chance = 5; } //JWR - Cap bonus at 5%
-                        if (!PlayerMPSync.stationary) // JWR
-                        {
-							Adj_dodge_chance += PlayerStats.Dodge_chance; // JWR - Add bonus if moving
-						}
-						else
-						{
-							Adj_dodge_chance = PlayerStats.Dodge_chance; // JWR - No bonus if stationary
-						}
-						if (Adj_dodge_chance > PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = PlayerStats.Dodge_hard_cap; } // JWR - still want hard cap
-						if (Random.Range(1, 100) <= Adj_dodge_chance)
+            		float Adj_dodge_chance = PlayerStats.Dodge_from_agi * pvp_dodge_bonus_modifier; //JWR - Moving dodge bonus based on agi (no gear)
+	    		if (PlayerStats.Dodge_chance >= (PlayerStats.Dodge_hard_cap - 5)) { Adj_dodge_chance = (PlayerStats.Dodge_chance + Adj_dodge_chance) - 45; }
+	    		if (PlayerStats.Dodge_chance >= PlayerStats.Dodge_hard_cap) { Adj_dodge_chance = 0; }
+            		if (Adj_dodge_chance > 5) { Adj_dodge_chance = 5; } //JWR - Cap bonus at 5%
+            		if (!PlayerMPSync.stationary) // JWR
+            		{
+				Adj_dodge_chance += PlayerStats.Dodge_chance; // JWR - Add bonus if moving
+	    		}
+            		else
+	    		{
+	    			Adj_dodge_chance = PlayerStats.Dodge_chance; // JWR - No bonus if stationary
+	    		}
+	                if (Random.Range(1, 100) <= Adj_dodge_chance) //JWR - Use adjusted dodge chance
                         {
                             DamageRX = 0;
                             dodged = true;

--- a/PlayerPVPDamage.cs
+++ b/PlayerPVPDamage.cs
@@ -282,13 +282,13 @@ public class PlayerPVPDamage : NetworkBehaviour
         {
             case PlayerStats.DamageType.magical:
                 playerTotalDef = PlayerStats.Defense_int + (PlayerStats.Defense_str * 0.2f);
-                playerTotalDef += pvpMdefBonus; //JWR - Add def bonus (general bonus for PvP balance)
+                //playerTotalDef += pvpMdefBonus; //JWR - Add def bonus (general bonus for PvP balance)
                 if (PlayerMPSync.stationary) { playerTotalDef += pvpMdefBonus; } //JWR - If stationary, double the defense bonus
                 fromPlayerDamage = fromPlayerStats.Damage_int;
                 break;
             case PlayerStats.DamageType.physical:
                 playerTotalDef = PlayerStats.Defense_str + (PlayerStats.Defense_int * 0.2f);
-                playerTotalDef += pvpPdefBonus; //JWR Add def bonus
+                //playerTotalDef += pvpPdefBonus; //JWR Add def bonus
                 if (PlayerMPSync.stationary) { playerTotalDef += pvpPdefBonus; } //JWR - If stationary, double the defense bonus
                 fromPlayerDamage = fromPlayerStats.Damage_str;
                 break;

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -79,6 +79,9 @@ public class PlayerStats : NetworkBehaviour
 
     public float Defense_str = 0;
     public float Defense_int = 0;
+    
+    public float Defense_from_pdef = 0; //JWR - Added label for pdef from stats
+    public float Defense_from_mdef = 0; //JWR - Added label for mdef from stats
 
     public float Critical_chance = 0;
     public float Critical_damage = 0;
@@ -391,6 +394,8 @@ public class PlayerStats : NetworkBehaviour
         }
 
         //defense
+        Defense_from_pdef = Defense_str * DEF; //JWR - Assign pdef from stats
+        Defense_from_mdef = Defense_int * MDEF; //JWR - Assign mdef from stats
         Defense_str = (Defense_str * DEF) + PlayerEquipStats[5];
         Defense_int = (Defense_int * MDEF) + PlayerEquipStats[6];
         if (Conditions.increasedDEF != 0f)

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -422,15 +422,15 @@ public class PlayerStats : NetworkBehaviour
         //Dodge
         Dodge_chance *= AGI;
         Dodge_chance += modDodge + PlayerEquipStats[7] + passive_dodge; //+passive_DodgeChance     
-        if (Dodge_chance > 50f)
+        if (Dodge_chance > 25f)
         {
-            Dodge_chance = (Dodge_chance - 50f) / 2f;
-            Dodge_chance += 50f;
+            Dodge_chance = (Dodge_chance - 25f) / 2f;
+            Dodge_chance += 25f;
         }
         Dodge_chance += Conditions.increasedDodge;
-        if (Dodge_chance > 90f)
+        if (Dodge_chance > 50f)
         {
-            Dodge_chance = 90f;
+            Dodge_chance = 50f;
         }
 
         //Regens

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -88,6 +88,8 @@ public class PlayerStats : NetworkBehaviour
 
     public float Dodge_chance = 0;
     public float Dodge_from_agi = 0; //JWR - Added label for dodge from stats
+    public float Dodge_soft_cap = 25f; //JWR - Added soft cap label for easier mod
+    public float Dodge_hard_cap = 50f; //JWR - Added hard cap label for easier mod
 
     public float AutoAtk_speed = 1f;
     public float AutoAtk_range = 1f;
@@ -429,15 +431,15 @@ public class PlayerStats : NetworkBehaviour
         Dodge_chance *= AGI;
         Dodge_from_agi = Dodge_chance; //JWR - Assign dodge from stats
         Dodge_chance += modDodge + PlayerEquipStats[7] + passive_dodge; //+passive_DodgeChance     
-        if (Dodge_chance > 25f)
+        if (Dodge_chance > Dodge_soft_cap)	//JWR changed from hard coded cap to label
         {
-            Dodge_chance = (Dodge_chance - 25f) / 2f;
-            Dodge_chance += 25f;
+            Dodge_chance = (Dodge_chance - Dodge_soft_cap) / 2f;
+            Dodge_chance += Dodge_soft_cap;
         }
         Dodge_chance += Conditions.increasedDodge;
-        if (Dodge_chance > 50f)
+        if (Dodge_chance > Dodge_hard_cap) //JWR changed from hard coded cap to label
         {
-            Dodge_chance = 50f;
+            Dodge_chance = Dodge_hard_cap;
         }
 
         //Regens

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -442,11 +442,11 @@ public class PlayerStats : NetworkBehaviour
             Dodge_chance = (Dodge_chance - Dodge_soft_cap) / 2f; 
             Dodge_chance += Dodge_soft_cap; 
         }
-        Dodge_chance += Conditions.increasedDodge;
         if (Dodge_chance > Dodge_hard_cap) //JWR changed from hard coded cap to label
         {
             Dodge_chance = Dodge_hard_cap;
         }
+        Dodge_chance += Conditions.increasedDodge;
 
         //Regens
         HP_regen_percent += modHPRegen + passive_HPRegen;

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -426,11 +426,11 @@ public class PlayerStats : NetworkBehaviour
             Critical_chance = (Critical_chance - CC_soft_cap) / 2f;
             Critical_chance += CC_soft_cap;
         }
-        Critical_chance += Conditions.increasedCritical;
         if (Critical_chance > CC_hard_cap) //JWR changed from hard coded cap to label
         {
             Critical_chance = CC_hard_cap;
         }
+        Critical_chance += Conditions.increasedCritical;
 
         //Dodge
         Dodge_chance *= AGI;

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -85,6 +85,8 @@ public class PlayerStats : NetworkBehaviour
 
     public float Critical_chance = 0;
     public float Critical_damage = 0;
+    public float CC_soft_cap = 25f; //JWR - Added soft cap label for easier mod
+    public float CC_hard_cap = 50f; //JWR - Added hard cap label for easier mod
 
     public float Dodge_chance = 0;
     public float Dodge_from_agi = 0; //JWR - Added label for dodge from stats
@@ -420,12 +422,16 @@ public class PlayerStats : NetworkBehaviour
         //Critical chance
         Critical_chance *= DEX;
         Critical_chance += modCritChance + passive_CritChance + PlayerEquipStats[1];
-        if (Critical_chance > 50f)
+        if (Critical_chance > CC_soft_cap) //JWR changed from hard coded cap to label
         {
-            Critical_chance = (Critical_chance - 50f) / 2f;
-            Critical_chance += 50f;
+            Critical_chance = (Critical_chance - CC_soft_cap) / 2f;
+            Critical_chance += CC_soft_cap;
         }
         Critical_chance += Conditions.increasedCritical;
+        if (Critical_chance > CC_hard_cap) //JWR changed from hard coded cap to label
+        {
+            Critical_chance = CC_hard_cap;
+        }
 
         //Dodge
         Dodge_chance *= AGI;
@@ -433,8 +439,8 @@ public class PlayerStats : NetworkBehaviour
         Dodge_chance += modDodge + PlayerEquipStats[7] + passive_dodge; //+passive_DodgeChance     
         if (Dodge_chance > Dodge_soft_cap)	//JWR changed from hard coded cap to label
         {
-            Dodge_chance = (Dodge_chance - Dodge_soft_cap) / 2f;
-            Dodge_chance += Dodge_soft_cap;
+            Dodge_chance = (Dodge_chance - Dodge_soft_cap) / 2f; 
+            Dodge_chance += Dodge_soft_cap; 
         }
         Dodge_chance += Conditions.increasedDodge;
         if (Dodge_chance > Dodge_hard_cap) //JWR changed from hard coded cap to label

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -89,7 +89,6 @@ public class PlayerStats : NetworkBehaviour
     public float CC_hard_cap = 50f; //JWR - Added hard cap label for easier mod
 
     public float Dodge_chance = 0;
-    public float Dodge_from_agi = 0; //JWR - Added label for dodge from stats
     public float Dodge_soft_cap = 25f; //JWR - Added soft cap label for easier mod
     public float Dodge_hard_cap = 50f; //JWR - Added hard cap label for easier mod
 
@@ -435,7 +434,6 @@ public class PlayerStats : NetworkBehaviour
 
         //Dodge
         Dodge_chance *= AGI;
-        Dodge_from_agi = Dodge_chance; //JWR - Assign dodge from stats
         Dodge_chance += modDodge + PlayerEquipStats[7] + passive_dodge; //+passive_DodgeChance     
         if (Dodge_chance > Dodge_soft_cap)	//JWR changed from hard coded cap to label
         {

--- a/PlayerStats.cs
+++ b/PlayerStats.cs
@@ -87,6 +87,7 @@ public class PlayerStats : NetworkBehaviour
     public float Critical_damage = 0;
 
     public float Dodge_chance = 0;
+    public float Dodge_from_agi = 0; //JWR - Added label for dodge from stats
 
     public float AutoAtk_speed = 1f;
     public float AutoAtk_range = 1f;
@@ -426,6 +427,7 @@ public class PlayerStats : NetworkBehaviour
 
         //Dodge
         Dodge_chance *= AGI;
+        Dodge_from_agi = Dodge_chance; //JWR - Assign dodge from stats
         Dodge_chance += modDodge + PlayerEquipStats[7] + passive_dodge; //+passive_DodgeChance     
         if (Dodge_chance > 25f)
         {


### PR DESCRIPTION
This pull should include:

Dodge buffs applied after dodge cap (affects acrobatics & final protection)
Dodge moving bonus modified to a flat 5%. Bonus limited to not exceed dodge cap. Affects:
PvE attacks
PvP autoattacks
PvP skill attacks
Defense stationary buff (PvP only). Bonus is calculated from pdef/mdef * class modifier * pvp_defense_bonus_modifier (no gear or buffs). The bonus modifier is current 0.5.
All other changes have been retracted or commented out.